### PR TITLE
Sapoepsilon/automatically login

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,39 +1,62 @@
 PODS:
+  - audio_service (0.0.1):
+    - Flutter
   - audio_session (0.0.1):
     - Flutter
-  - audioplayer (0.0.1):
-    - Flutter
   - Flutter (1.0.0)
+  - FMDB (2.7.5):
+    - FMDB/standard (= 2.7.5)
+  - FMDB/standard (2.7.5)
   - just_audio (0.0.1):
     - Flutter
-  - path_provider_ios (0.0.1):
+  - path_provider_foundation (0.0.1):
     - Flutter
+    - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - sqflite (0.0.2):
+    - Flutter
+    - FMDB (>= 2.7.5)
 
 DEPENDENCIES:
+  - audio_service (from `.symlinks/plugins/audio_service/ios`)
   - audio_session (from `.symlinks/plugins/audio_session/ios`)
-  - audioplayer (from `.symlinks/plugins/audioplayer/ios`)
   - Flutter (from `Flutter`)
   - just_audio (from `.symlinks/plugins/just_audio/ios`)
-  - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
+  - sqflite (from `.symlinks/plugins/sqflite/ios`)
+
+SPEC REPOS:
+  trunk:
+    - FMDB
 
 EXTERNAL SOURCES:
+  audio_service:
+    :path: ".symlinks/plugins/audio_service/ios"
   audio_session:
     :path: ".symlinks/plugins/audio_session/ios"
-  audioplayer:
-    :path: ".symlinks/plugins/audioplayer/ios"
   Flutter:
     :path: Flutter
   just_audio:
     :path: ".symlinks/plugins/just_audio/ios"
-  path_provider_ios:
-    :path: ".symlinks/plugins/path_provider_ios/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/ios"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/ios"
+  sqflite:
+    :path: ".symlinks/plugins/sqflite/ios"
 
 SPEC CHECKSUMS:
+  audio_service: f509d65da41b9521a61f1c404dd58651f265a567
   audio_session: 4f3e461722055d21515cf3261b64c973c062f345
-  audioplayer: 0584f31a697e4b0bbad405ae7903d7a93585e784
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   just_audio: baa7252489dbcf47a4c7cc9ca663e9661c99aafa
-  path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
+  path_provider_foundation: 37748e03f12783f9de2cb2c4eadfaa25fe6d4852
+  shared_preferences_foundation: 297b3ebca31b34ec92be11acd7fb0ba932c822ca
+  sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
 
 PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3
 

--- a/lib/helpers/globals.dart
+++ b/lib/helpers/globals.dart
@@ -1,0 +1,1 @@
+String isLoggedInKey = "isLoggedIn";

--- a/lib/login.dart
+++ b/lib/login.dart
@@ -115,7 +115,6 @@ class _Login extends State<Login> {
         savedCredentiais.forEach((key, value) {
           if (key == "username") {
             _username = value;
-            print("Username: $_username");
           } else if (key == "password") {
             _password = value;
           } else if (key == "server") {
@@ -158,6 +157,7 @@ class _Login extends State<Login> {
               subSonicContext:
                   // ignore: todo
                   ctx),
+          // ignore: todo
           context: context)); //TODO: do not use Navigator in async method
     } else {
       // ignore: use_build_context_synchronously
@@ -192,7 +192,6 @@ class _Login extends State<Login> {
   Widget field(bool isTablet, Size screenSize, String userValue, hintText,
       Function function,
       [bool? isPassword]) {
-    debugPrint("field: $userValue");
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[

--- a/lib/login.dart
+++ b/lib/login.dart
@@ -2,6 +2,8 @@
 
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
+import 'package:streamer/helpers/globals.dart';
 import 'package:streamer/home.dart';
 import 'package:streamer/helpers/helpers.dart';
 import 'package:streamer/subsonic/context.dart';
@@ -21,10 +23,37 @@ class _Login extends State<Login> {
   String _server = "";
   String _username = "";
   String _password = "";
+  bool isRemeberMe = false;
+
+  @override
+  void initState() {
+    super.initState();
+    checkCredentials();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    final isTablet = MediaQuery.of(context).size.width > 600;
+    final screenSize = MediaQuery.of(context).size;
+    GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+    return PlatformScaffold(
+      material: (context, platform) {
+        return MaterialScaffoldData(
+            floatingActionButton: FloatingActionButton(
+              onPressed: () {
+                scaffoldKey.currentState?.openEndDrawer();
+              },
+              backgroundColor: Colors.transparent,
+              child: const Icon(Icons.menu),
+            ),
+            floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
+            endDrawer: Drawer(
+              backgroundColor: const Color.fromARGB(100, 0, 0, 0),
+              child: DrawerHeader(
+                  child: Image.network(
+                      "https://avatars.githubusercontent.com/u/108163041?s=96&v=4")),
+            ));
+      },
       body: AnnotatedRegion<SystemUiOverlayStyle>(
         value: SystemUiOverlayStyle.light,
         child: GestureDetector(
@@ -41,33 +70,35 @@ class _Login extends State<Login> {
                   ],
                   radius: .8,
                 )),
-                child: SingleChildScrollView(
-                  // physics: AlwaysScrollableScrollPhysics(),
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 25, vertical: 120),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      const Text(
-                        "Streamer",
-                        style: TextStyle(
-                            color: Colors.white,
-                            fontSize: 32,
-                            fontWeight: FontWeight.bold),
-                      ),
-                      const SizedBox(height: 130),
-                      server(),
-                      const SizedBox(height: 20),
-                      name(),
-                      const SizedBox(height: 20),
-                      username(),
-                      const SizedBox(height: 20),
-                      password(),
-                      const SizedBox(height: 70),
-                      conect()
-                      // buildforgotPassBtn(),
-                    ],
-                  ),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    PlatformText(
+                      "Streamer",
+                      style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 32,
+                          fontWeight: FontWeight.bold),
+                    ),
+                    SizedBox(
+                      height: screenSize.height * 0.15,
+                    ),
+                    field(isTablet, screenSize, _server,
+                        "http://89.207.132.170:4533", _getServerValuetext),
+                    textFieldSpacer(screenSize),
+                    field(
+                        isTablet, screenSize, _name, "Name", _getNameValuetext),
+                    textFieldSpacer(screenSize),
+                    field(isTablet, screenSize, _username, "Username",
+                        _getUsernameValuetext),
+                    textFieldSpacer(screenSize),
+                    field(isTablet, screenSize, _password, "Password",
+                        _getPasswordValuetext, true),
+                    textFieldSpacer(screenSize),
+                    rememberMe(isTablet, screenSize),
+                    conect(isTablet, screenSize)
+                    // buildforgotPassBtn(),
+                  ],
                 ),
               ),
             ],
@@ -77,122 +108,28 @@ class _Login extends State<Login> {
     );
   }
 
-  Widget server() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Container(
-          alignment: Alignment.centerLeft,
-          decoration: loginTextFieldBackground(),
-          height: 60,
-          child: TextField(
-            keyboardType: TextInputType.text,
-            onChanged: (value) {
-              setState(() {
-                _server = value;
-              });
-            },
-            style: const TextStyle(color: Colors.white),
-            decoration: loginTextDecoration("123.456.789.123"),
-          ),
-        )
-      ],
-    );
-  }
-
-  Widget password() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Container(
-          alignment: Alignment.centerLeft,
-          decoration: loginTextFieldBackground(),
-          height: 60,
-          child: TextField(
-            obscureText: true,
-            onChanged: (value) {
-              setState(() {
-                _password = value;
-              });
-            },
-            style: const TextStyle(color: Colors.white),
-            decoration: loginTextDecoration("Password"),
-          ),
-        )
-      ],
-    );
-  }
-
-  Widget name() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Container(
-          alignment: Alignment.centerLeft,
-          decoration: loginTextFieldBackground(),
-          height: 60,
-          child: TextField(
-              keyboardType: TextInputType.text,
-              onChanged: (value) {
-                setState(() {
-                  _name = value;
-                });
-              },
-              style: const TextStyle(color: Colors.white),
-              decoration: loginTextDecoration("Name")),
-        )
-      ],
-    );
-  }
-
-  Widget username() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Container(
-          alignment: Alignment.centerLeft,
-          decoration: loginTextFieldBackground(),
-          height: 60,
-          child: TextField(
-            keyboardType: TextInputType.text,
-            onChanged: (value) {
-              setState(() {
-                _username = value;
-              });
-            },
-            style: const TextStyle(color: Colors.white),
-            decoration: loginTextDecoration("Username"),
-          ),
-        )
-      ],
-    );
-  }
-
-  Widget conect() {
-    return Container(
-      padding: const EdgeInsets.symmetric(vertical: 25),
-      width: double.infinity,
-      child: ElevatedButton(
-        onPressed: _connectToServer,
-        style: ElevatedButton.styleFrom(
-            minimumSize: const Size(80, 60),
-            backgroundColor: Colors.purple.shade900,
-            shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(45))),
-        child: const Text(
-          "Conect",
-          style: TextStyle(
-            color: Color.fromARGB(222, 24, 167, 214),
-            fontSize: 20,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-      ),
-    );
+  void checkCredentials() async {
+    if (await getBool(isLoggedInKey)) {
+      final savedCredentiais = await getCredentials();
+      setState(() {
+        savedCredentiais.forEach((key, value) {
+          if (key == "username") {
+            _username = value;
+            print("Username: $_username");
+          } else if (key == "password") {
+            _password = value;
+          } else if (key == "server") {
+            _server = value;
+          }
+        });
+      });
+      _connectToServer();
+    }
   }
 
   void _connectToServer() async {
     // ignore: unused_local_variable
+    debugPrint("server: $_server");
     String errorMessage = "";
     final ctx = SubsonicContext(
         serverId: "Docker",
@@ -216,14 +153,135 @@ class _Login extends State<Login> {
       // ignore: todo
       // TODO: move methods with context out of Async method
       // ignore: use_build_context_synchronously
-      Navigator.of(context).push(MaterialPageRoute(
+      Navigator.of(context).push(platformPageRoute(
           builder: (context) => Home(
               subSonicContext:
                   // ignore: todo
-                  ctx))); //TODO: do not use Navigator in async method
+                  ctx),
+          context: context)); //TODO: do not use Navigator in async method
     } else {
       // ignore: use_build_context_synchronously
       showErrorDialog(context, errorMessage);
     }
+  }
+
+  void _getServerValuetext(String value) {
+    setState(() {
+      _server = value;
+    });
+  }
+
+  void _getNameValuetext(String value) {
+    setState(() {
+      _name = value;
+    });
+  }
+
+  void _getUsernameValuetext(String value) {
+    setState(() {
+      _username = value;
+    });
+  }
+
+  void _getPasswordValuetext(String value) {
+    setState(() {
+      _password = value;
+    });
+  }
+
+  Widget field(bool isTablet, Size screenSize, String userValue, hintText,
+      Function function,
+      [bool? isPassword]) {
+    debugPrint("field: $userValue");
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Container(
+            width: isTablet ? 500 : screenSize.width * 0.8,
+            decoration: loginTextFieldBackground(),
+            child: PlatformTextFormField(
+              initialValue: userValue,
+              material: (context, platform) {
+                return MaterialTextFormFieldData(
+                  decoration: const InputDecoration(
+                    hintStyle: TextStyle(color: Colors.grey),
+                    contentPadding: EdgeInsets.symmetric(horizontal: 10),
+                  ),
+                );
+              },
+              obscureText: isPassword ?? false,
+              keyboardType: TextInputType.text,
+              onChanged: (value) {
+                function(value);
+              },
+              hintText: hintText,
+              style: const TextStyle(color: Colors.white),
+            )),
+      ],
+    );
+  }
+
+  Widget conect(bool isTablet, Size screenSize) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 25),
+      width: isTablet ? 500 : screenSize.width * 0.8,
+      child: PlatformElevatedButton(
+        material: (context, platform) {
+          return MaterialElevatedButtonData(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.purple.shade900,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(45),
+              ),
+              fixedSize: const Size(80, 60),
+            ),
+          );
+        },
+        onPressed: _connectToServer,
+        child: const Text(
+          "Conect",
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget textFieldSpacer(Size screenSize) {
+    return SizedBox(
+      height: screenSize.height * 0.05,
+    );
+  }
+
+  Widget rememberMe(bool isTablet, Size screenSize) {
+    return SizedBox(
+      height: 20,
+      width: isTablet ? 500 : screenSize.width * 0.8,
+      child: Row(mainAxisAlignment: MainAxisAlignment.end, children: <Widget>[
+        const Text(
+          "Remember Me",
+          style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+        ),
+        PlatformSwitch(
+          value: isRemeberMe,
+          onChanged: (value) {
+            setState(() {
+              isRemeberMe = value;
+              saveUser(isLoggedInKey, isRemeberMe);
+              if (isRemeberMe) {
+                saveCredentials(
+                  _server,
+                  _username,
+                  _password,
+                );
+              }
+            });
+          },
+        ),
+      ]),
+    );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'login.dart';
-
 
 void main() {
   runApp(const MyApp());
@@ -11,10 +12,23 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      title: "Login",
-      debugShowCheckedModeBanner: false,
-      home: Login(),
+    return PlatformProvider(
+      builder: (context) => PlatformApp(
+        cupertino: (context, platform) {
+          return CupertinoAppData(
+            theme: const CupertinoThemeData(
+              textTheme: CupertinoTextThemeData(),
+            ),
+          );
+        },
+        localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+          DefaultMaterialLocalizations.delegate,
+          DefaultWidgetsLocalizations.delegate,
+          DefaultCupertinoLocalizations.delegate,
+        ],
+        title: 'Flutter Platform Widgets',
+        home: const Login(),
+      ),
     );
   }
 }

--- a/lib/utils/shared_preferences.dart
+++ b/lib/utils/shared_preferences.dart
@@ -20,3 +20,15 @@ Future<Map<String, String>> getCredentials() async {
     "server": server ?? "noServer"
   };
 }
+
+// save boolean
+void saveUser(String key, bool value) async {
+  final prefs = await SharedPreferences.getInstance();
+  prefs.setBool(key, value);
+}
+
+// retrieve boolean
+Future<bool> getBool(String key) async {
+  final prefs = await SharedPreferences.getInstance();
+  return prefs.getBool(key) ?? false;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -118,6 +118,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  flutter_platform_widgets:
+    dependency: "direct main"
+    description:
+      name: flutter_platform_widgets
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   path_provider: ^2.0.12
   collection:
   pedantic: ^1.11.1
+  flutter_platform_widgets: ^2.2.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- [x] Used platform specific widgets. Cupertino for iOS, and Material for Android 
- [x] Save credentials, on remember me toggle
- [x] Automatically navigate to Home page if the user decides to save the credentials after the first login
- [x] Changed static spacing between the fields to Dynamic. That would automatically adjust depending the ratio of the device. 
- [x] Removed scrolling as it seemed unnecessary for the login, and would scroll on non standard screen proportions. 

#21  This PR addresses all the comments I have made. This PR still needs to include all the other saved credentials. 
## @DereckAn  Would like to work on those? We could use drawer on Android, and how about incorporating "key" icon for iOS (kinda like Safari does), and once user touches that icon, the app would display all the other credentials? 

## Demo



![Login screen](https://user-images.githubusercontent.com/47342870/218247582-57f425e6-8d2e-46b8-96dd-a850173c46b7.gif)

